### PR TITLE
fix: rename duplicate omniwire_cookies to cybersync_cookies

### DIFF
--- a/src/mcp/sync-tools.ts
+++ b/src/mcp/sync-tools.ts
@@ -269,10 +269,10 @@ export function registerSyncTools(
     }
   );
 
-  // --- Tool 35: omniwire_cookies ---
+  // --- Tool 35: cybersync_cookies ---
   server.tool(
-    'omniwire_cookies',
-    'Manage browser cookies across mesh nodes. Store/retrieve/import/export in json/header/netscape format and sync to remote nodes via SSH.',
+    'cybersync_cookies',
+    'Manage browser cookies across mesh nodes with CyberBase persistence. Store/retrieve/import/export in json/header/netscape format and sync to remote nodes via SSH.',
     {
       action: z.enum(['set', 'get', 'list', 'delete', 'import', 'export', 'sync']).describe('Action to perform'),
       domain: z.string().optional().describe('Cookie domain (required for set/get/delete/sync/export)'),


### PR DESCRIPTION
## Summary

- `omniwire_cookies` is registered in both `server.ts` (core, in-memory) and `sync-tools.ts` (CyberBase-backed with mesh sync)
- When CyberSync is enabled, MCP server crashes on startup: `Tool omniwire_cookies is already registered`
- Renames the sync-tools version to `cybersync_cookies` to match the `cybersync_*` naming convention

## Details

The two implementations serve different purposes — core does file-based storage with format conversion, sync does DB-persisted CRUD with mesh sync. Both are useful, but the name collision prevents CyberSync from loading.

The `cybersync_` prefix is consistent with the other sync tools (`cybersync_status`, `cybersync_sync_now`, `cybersync_diff`, etc.).

## Test

Start OmniWire with CyberSync enabled (Postgres configured, no `--no-sync`). Before this fix: crash. After: both `omniwire_cookies` and `cybersync_cookies` register successfully.