### PR TITLE
feat: add --bind flag for SSE/REST/Events servers

### DIFF
--- a/src/mcp/events.ts
+++ b/src/mcp/events.ts
@@ -252,7 +252,7 @@ export const eventBus = new OmniWireEventBus();
 
 // --- HTTP + WebSocket Server ---
 
-export function startEventServer(port: number): void {
+export function startEventServer(port: number, bind = '127.0.0.1'): void {
   const httpServer = createHttpServer((req: IncomingMessage, res: ServerResponse) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
@@ -371,5 +371,5 @@ export function startEventServer(port: number): void {
     }
   });
 
-  httpServer.listen(port, '0.0.0.0');
+  httpServer.listen(port, bind);
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -25,6 +25,7 @@ const useJson = args.includes('--json');
 const ssePort = parseInt(args.find((a) => a.startsWith('--sse-port='))?.split('=')[1] ?? '3200');
 const restPort = parseInt(args.find((a) => a.startsWith('--rest-port='))?.split('=')[1] ?? '3201');
 const eventPort = parseInt(args.find((a) => a.startsWith('--event-port='))?.split('=')[1] ?? '3202');
+const bindAddr = args.find((a) => a.startsWith('--bind='))?.split('=')[1] ?? '127.0.0.1';
 const noSync = args.includes('--no-sync');
 const noEvents = args.includes('--no-events');
 
@@ -89,13 +90,13 @@ async function main(): Promise<void> {
     const transport = new StdioServerTransport();
     await server.connect(transport);
   } else {
-    startSSEServer(server, ssePort);
-    startRESTServer(manager, transfer, restPort);
+    startSSEServer(server, ssePort, bindAddr);
+    startRESTServer(manager, transfer, restPort, bindAddr);
     if (!noEvents) {
-      startEventServer(eventPort);
-      log(`Events: WS+SSE+Webhooks on :${eventPort}`, { eventPort });
+      startEventServer(eventPort, bindAddr);
+      log(`Events: WS+SSE+Webhooks on ${bindAddr}:${eventPort}`, { eventPort });
     }
-    log(`OmniWire MCP: SSE on :${ssePort}, REST on :${restPort}`, { ssePort, restPort });
+    log(`OmniWire MCP: SSE on ${bindAddr}:${ssePort}, REST on ${bindAddr}:${restPort}`, { ssePort, restPort });
   }
 
   process.on('SIGINT', async () => {

--- a/src/mcp/rest.ts
+++ b/src/mcp/rest.ts
@@ -21,7 +21,7 @@ function json(res: ServerResponse, status: number, data: unknown): void {
   res.end(JSON.stringify(data));
 }
 
-export function startRESTServer(manager: NodeManager, transfer: TransferEngine, port: number): void {
+export function startRESTServer(manager: NodeManager, transfer: TransferEngine, port: number, bind = '127.0.0.1'): void {
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     res.setHeader('Access-Control-Allow-Origin', 'http://localhost');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS');
@@ -117,5 +117,5 @@ export function startRESTServer(manager: NodeManager, transfer: TransferEngine, 
     }
   });
 
-  httpServer.listen(port, '127.0.0.1');
+  httpServer.listen(port, bind);
 }

--- a/src/mcp/sse.ts
+++ b/src/mcp/sse.ts
@@ -6,7 +6,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
-export function startSSEServer(server: McpServer, port: number): void {
+export function startSSEServer(server: McpServer, port: number, bind = '127.0.0.1'): void {
   let transport: SSEServerTransport | null = null;
 
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
@@ -49,5 +49,5 @@ export function startSSEServer(server: McpServer, port: number): void {
     res.end(JSON.stringify({ error: 'Not found. Endpoints: GET /sse, POST /message, GET /health' }));
   });
 
-  httpServer.listen(port, '127.0.0.1');
+  httpServer.listen(port, bind);
 }


### PR DESCRIPTION
## Summary

- SSE and REST servers are hardcoded to `127.0.0.1`, preventing remote MCP clients from connecting
- Events server is hardcoded to `0.0.0.0` independently
- Adds `--bind=<addr>` CLI flag (default: `127.0.0.1`) for all three servers

## Details

When running OmniWire as an SSE MCP server for remote clients (e.g., over a VPN or private network), the hardcoded localhost bind makes the SSE and REST endpoints unreachable. This adds a `--bind` flag to opt in to network exposure:

```bash
# Local only (default, same as current behavior for SSE/REST)
node dist/mcp/index.js

# Allow remote connections
node dist/mcp/index.js --bind=0.0.0.0
```

**Breaking change note:** The Events server was previously `0.0.0.0` and now defaults to `127.0.0.1` for consistency. Deployments relying on remote event connections should add `--bind=0.0.0.0` explicitly.

Stdio mode is unaffected.

## Test

```bash
# Default: localhost only
node dist/mcp/index.js
curl http://127.0.0.1:3200/health  # works
curl http://<lan-ip>:3200/health   # refused

# With --bind:
node dist/mcp/index.js --bind=0.0.0.0
curl http://<lan-ip>:3200/health   # works
```