### PR TITLE
feat: support CYBERSYNC_DB_URL env var for Postgres connection

### DIFF
--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -96,12 +96,33 @@ export interface SyncConfig {
   readonly reconcileIntervalMs: number;
 }
 
+// Parse CYBERSYNC_DB_URL (postgresql://user:pass@host:port/db) if set
+function parseDbUrl(): Partial<Pick<SyncConfig, 'pgHost' | 'pgPort' | 'pgDatabase' | 'pgUser' | 'pgPassword'>> {
+  const url = process.env.CYBERSYNC_DB_URL;
+  if (!url) return {};
+  try {
+    const u = new URL(url);
+    return {
+      pgHost: u.hostname || undefined,
+      pgPort: u.port ? parseInt(u.port, 10) : undefined,
+      pgDatabase: u.pathname.slice(1) || undefined,
+      pgUser: decodeURIComponent(u.username) || undefined,
+      pgPassword: decodeURIComponent(u.password) || undefined,
+    };
+  } catch {
+    process.stderr.write(`Warning: invalid CYBERSYNC_DB_URL, using defaults\n`);
+    return {};
+  }
+}
+
+const _dbUrl = parseDbUrl();
+
 export const DEFAULT_SYNC_CONFIG: Omit<SyncConfig, 'nodeId'> = {
-  pgHost: '10.10.0.1',
-  pgPort: 5432,
-  pgDatabase: 'cyberbase',
-  pgUser: 'cyberbase',
-  pgPassword: process.env.OW_PG_PASSWORD ?? 'cyberbase',
+  pgHost: _dbUrl.pgHost ?? '10.10.0.1',
+  pgPort: _dbUrl.pgPort ?? 5432,
+  pgDatabase: _dbUrl.pgDatabase ?? 'cyberbase',
+  pgUser: _dbUrl.pgUser ?? 'cyberbase',
+  pgPassword: _dbUrl.pgPassword ?? process.env.OW_PG_PASSWORD ?? 'cyberbase',
   watchDebounceMs: 300,
   reconcileIntervalMs: 2 * 60 * 1000,  // 2min (was 5min)  faster convergence
 };


### PR DESCRIPTION
## Summary

- CyberSync Postgres config is hardcoded (`10.10.0.1`, `cyberbase` db/user)
- Only `OW_PG_PASSWORD` is overridable via env var
- Adds `CYBERSYNC_DB_URL` env var support — standard `postgresql://` connection URL

## Details

This enables external Postgres deployments without source modification:

```bash
export CYBERSYNC_DB_URL="postgresql://omniwire:secret@db-host:5432/omniwire"
node dist/mcp/index.js
```

Individual fields from the URL override defaults; unset fields fall through to existing hardcoded values. The `OW_PG_PASSWORD` env var still works as a middle fallback.

Precedence: `CYBERSYNC_DB_URL` fields > `OW_PG_PASSWORD` > hardcoded defaults.

**Design note:** Considered using `pg`'s native `connectionString` support in the Pool constructor, but config-level parsing in `types.ts` keeps resolution centralized and allows the existing individual field overrides to still work. Happy to refactor if you'd prefer the `connectionString` approach.

Invalid URLs log a warning to stderr and fall back to defaults rather than crashing.

## Test

```bash
# Without env var: uses existing defaults (backward compatible)
node dist/mcp/index.js

# With env var: connects to specified Postgres
CYBERSYNC_DB_URL="postgresql://user:pass@host:5432/db" node dist/mcp/index.js

# With malformed URL: warns and falls back
CYBERSYNC_DB_URL="not-a-url" node dist/mcp/index.js
# stderr: Warning: invalid CYBERSYNC_DB_URL, using defaults
```