### PR TITLE
sync/paths: allow home directory overrides via env vars

### DIFF
--- a/src/sync/manifest.ts
+++ b/src/sync/manifest.ts
@@ -1,7 +1,7 @@
 // CyberSync — Tool manifests defining what to sync per AI tool
 
 import type { ToolManifest, ToolName } from './types.js';
-import { getToolBaseDir } from './paths.js';
+import { getHomeForOs, getToolBaseDir } from './paths.js';
 
 function manifest(tool: ToolName, os: 'windows' | 'linux', sync: string[], exclude: string[], ingestDb?: string, ingestDirs?: string[]): ToolManifest {
   return {
@@ -15,7 +15,7 @@ function manifest(tool: ToolName, os: 'windows' | 'linux', sync: string[], exclu
 }
 
 export function getManifests(os: 'windows' | 'linux'): readonly ToolManifest[] {
-  const home = os === 'windows' ? 'C:/Users/Admin' : '/root';
+  const home = getHomeForOs(os);
 
   return [
     manifest('claude-code', os,

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -1,8 +1,24 @@
 // CyberSync — Windows/Linux path adaptation for JSON content
 
-const WIN_HOME = 'C:/Users/Admin';
-const WIN_HOME_BACKSLASH = 'C:\\Users\\Admin';
-const LINUX_HOME = '/root';
+import { homedir } from 'node:os';
+
+// Upstream defaults preserve container-style assumptions:
+//   Windows -> C:/Users/Admin (upstream author's username)
+//   Linux   -> /root (upstream runs as root inside containers)
+//
+// OMNIWIRE_{WIN,LINUX}_HOME env vars override these, so non-root Linux
+// hosts and Windows hosts with different usernames can deploy without
+// forking. When the LINUX override is unset, we detect root vs non-root
+// so upstream's root-container behavior is unchanged.
+const WIN_HOME = (process.env.OMNIWIRE_WIN_HOME ?? 'C:/Users/Admin').replaceAll('\\', '/');
+const WIN_HOME_BACKSLASH = WIN_HOME.replaceAll('/', '\\');
+const LINUX_HOME = process.env.OMNIWIRE_LINUX_HOME
+  ?? (process.getuid?.() === 0 ? '/root' : homedir());
+
+/** Returns the canonical home directory for the given OS target */
+export function getHomeForOs(os: 'windows' | 'linux'): string {
+  return os === 'windows' ? WIN_HOME : LINUX_HOME;
+}
 
 const PATH_MAPS: ReadonlyArray<readonly [string, string]> = [
   [WIN_HOME_BACKSLASH, LINUX_HOME],


### PR DESCRIPTION
## Summary

Hardcoded `WIN_HOME='C:/Users/Admin'` and `LINUX_HOME='/root'` in `src/sync/paths.ts` assume the upstream author's usernames and container-as-root deployment model. Non-root Linux hosts and Windows hosts with different usernames silently skip all manifests because `existsSync(baseDir)` returns false at `src/sync/watcher.ts:35` and `src/sync/engine.ts:135`.

### Changes

- Add `OMNIWIRE_{WIN,LINUX}_HOME` env var overrides
- When `OMNIWIRE_LINUX_HOME` is unset, detect root vs non-root via `process.getuid()` so container deployments still get `/root` while host deployments get `homedir()` instead of silently watching nonexistent `/root/.claude`
- Export a shared `getHomeForOs(os)` helper
- Fix `src/sync/manifest.ts` which shadowed the home directory with a duplicate hardcoded string, causing ingest paths to diverge from baseDir

### Backwards compatibility

Bit-identical behavior for upstream when env vars are unset AND running as root on Linux. Non-root Linux hosts get the `homedir()` fallback instead of silently failing.

## Test plan

- [x] `tsc` builds clean
- [x] Manual trace: `getHomeForOs('linux')` returns `homedir()` on non-root, `/root` under root (fakeroot simulation)
- [x] Manual trace: `OMNIWIRE_LINUX_HOME=/tmp/fakehome` override respected
- [x] Caller trace: watcher/engine/manifest all pick up env overrides transparently