### PR TITLE
mcp: add stdio parent-death watchdog to prevent orphan accumulation

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -99,11 +99,49 @@ async function main(): Promise<void> {
     log(`OmniWire MCP: SSE on ${bindAddr}:${ssePort}, REST on ${bindAddr}:${restPort}`, { ssePort, restPort });
   }
 
-  process.on('SIGINT', async () => {
-    if (syncDb) await syncDb.close();
-    manager.disconnect();
+  let shuttingDown = false;
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log(`shutdown: ${reason}`, { shutdown: true, reason });
+    try { if (syncDb) await syncDb.close(); } catch { /* best effort */ }
+    try { manager.disconnect(); } catch { /* best effort */ }
     process.exit(0);
-  });
+  };
+
+  // Signal-based shutdown — applies to both stdio and SSE transports.
+  // MCP SDK client kill ladder: stdin.end() -> SIGTERM -> SIGKILL.
+  process.on('SIGINT', () => { void shutdown('SIGINT'); });
+  process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
+  process.on('SIGHUP', () => { void shutdown('SIGHUP'); });
+
+  if (useStdio) {
+    // StdioServerTransport only registers 'data'/'error' on stdin and never
+    // closes it, so 'end'/'close' only fire when the parent closes the pipe.
+    process.stdin.on('end', () => { void shutdown('stdin-end'); });
+    process.stdin.on('close', () => { void shutdown('stdin-close'); });
+
+    // Parent-PID watchdog: NodeManager's ssh2 keepalive pins the event loop,
+    // so Node won't exit naturally when the parent dies. Poll ppid and probe
+    // parent existence every 5s. Unref so the timer itself doesn't keep us
+    // alive.
+    const initialPpid = process.ppid;
+    const ppidTimer = setInterval(() => {
+      const currentPpid = process.ppid;
+      if (currentPpid !== initialPpid || currentPpid <= 1) {
+        void shutdown('parent-gone (reparent)');
+        return;
+      }
+      try {
+        process.kill(currentPpid, 0);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+          void shutdown('parent-gone (ESRCH)');
+        }
+      }
+    }, 5_000);
+    ppidTimer.unref();
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Under `--stdio` mode, `NodeManager` holds 5 persistent ssh2 connections with 2s keepalive. These pin the event loop indefinitely, so the usual "parent dies, stdin closes, Node drains and exits" assumption does not hold. Uncleanly terminated parent processes leave behind orphaned stdio children that accumulate until manual cleanup (observed: ~70 children on one deployment over 48h, ~43 of them reapable by the criteria below).

The MCP SDK client shutdown ladder is `stdin.end()` → 2s → `SIGTERM` → 2s → `SIGKILL`. The current server only handles `SIGINT`, which the client never sends.

### Changes

Add three dormant-in-normal-operation termination paths to `src/mcp/index.ts`, gated on `useStdio` so SSE daemons are unaffected:

1. **SIGTERM/SIGHUP handlers** (in addition to existing SIGINT) for orderly client-initiated shutdown
2. **`process.stdin` 'end'/'close' listeners**. `StdioServerTransport` never closes stdin itself (verified against `@modelcontextprotocol/sdk` source), so these only fire when the parent closes the pipe — the MCP SDK's canonical first shutdown step
3. **Parent-PID watchdog** (5s interval, `unref()`'d) that triggers shutdown if `ppid` changes (reparented to init) or `kill(ppid, 0)` returns `ESRCH`. Belt-and-suspenders for the ssh2-keeps-loop-alive case

All three call a single idempotent `shutdown()` guarded by a `shuttingDown` flag that closes `syncDb` and calls `manager.disconnect()` before `process.exit(0)`.

## Test plan

- [x] `tsc` builds clean
- [x] Test 1 (SIGTERM): stderr logged `shutdown: SIGTERM`, process exited cleanly
- [x] Test 2 (stdin EOF): stderr logged `shutdown: stdin-end`, process exited cleanly
- [x] Correctness logically verified for watchdog path (setInterval unref'd, ESRCH branch guarded by `shuttingDown`)