### PR TITLE
sync/db: make statement_timeout configurable via env var

### DIFF
--- a/src/sync/db.ts
+++ b/src/sync/db.ts
@@ -17,7 +17,7 @@ export class SyncDB {
       max: 8,
       idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 5_000,
-      statement_timeout: 10_000,
+      statement_timeout: process.env.CYBERSYNC_STATEMENT_TIMEOUT_MS ? Number(process.env.CYBERSYNC_STATEMENT_TIMEOUT_MS) : 10_000,
     });
   }
 


### PR DESCRIPTION
## Summary

The hardcoded 10s `statement_timeout` in `src/sync/db.ts:20` causes reconcile failures when the `sync_items` table grows beyond a few hundred MB. During a cross-mesh deployment, the full initial reconcile pulled ~580MB of OpenClaw knowledge and exceeded 10 seconds over Tailscale — every affected node's sync daemon was crash-looping on \`Fatal: canceling statement due to statement timeout\` until the reconcile query was interrupted.

### Changes

Single one-line change: read from \`CYBERSYNC_STATEMENT_TIMEOUT_MS\` if set, otherwise fall through to the existing 10_000 default.

```diff
- statement_timeout: 10_000,
+ statement_timeout: process.env.CYBERSYNC_STATEMENT_TIMEOUT_MS ? Number(process.env.CYBERSYNC_STATEMENT_TIMEOUT_MS) : 10_000,
```

### Backwards compatibility

Default unchanged (10s) when env var is unset. Upstream container deployments see no behavior change. Deployments that hit this wall can opt in to a higher timeout (e.g., 120000 for 2 minutes) without patching source.

## Test plan

- [x] \`tsc\` builds clean
- [x] Verified on live deployment: Windows node with \`CYBERSYNC_STATEMENT_TIMEOUT_MS=120000\` completed initial reconcile (1295 items pushed) where the unpatched code crashed at 10s